### PR TITLE
problem: header shows negative values

### DIFF
--- a/src/components/layout/Header/index.js
+++ b/src/components/layout/Header/index.js
@@ -5,7 +5,7 @@ import screen from '../../../store/wallet/screen';
 
 export default muiThemeable()(connect(
   (state, ownProps) => {
-    const showProgress = state.launcher.getIn(['geth', 'type']) === 'local';
+    const showProgress = state.launcher.getIn(['geth', 'type']) === 'local' && state.network.getIn(['sync', 'syncing']);
     const curBlock = state.network.getIn(['currentBlock', 'height'], -1);
     const tip = state.network.getIn(['sync', 'highestBlock'], -1);
     const progress = (curBlock / tip) * 100;


### PR DESCRIPTION
solution: only show sync progress when actually 'syncing'

note:
theres an underlying issue here where the `network.sync.highestBlock` and `network.currentBlock.height` will be out of sync because they are on different timers.

fixes #517 