### PR TITLE
problem: can't switch network on welcome screen

### DIFF
--- a/src/components/layout/Main/main.js
+++ b/src/components/layout/Main/main.js
@@ -12,10 +12,10 @@ import './main.scss';
 
 const maxWidth = '1150px';
 
-const Render = translate('common')(({ t, ...props }) => {
+const Render = translate('common')(({ ...props }) => {
   return (
     <div>
-      {props.screen !== 'paper-wallet' && <Header maxWidth={ maxWidth }/>}
+      {props.screen !== 'paper-wallet' && (!props.launcherType || props.launcherType !== 'none') && <Header />}
       <div style={{margin: '20px auto', maxWidth}}>
         <Screen />
       </div>
@@ -30,6 +30,7 @@ const Render = translate('common')(({ t, ...props }) => {
 const Main = connect(
   (state, ownProps) => ({
     screen: state.wallet.screen.get('screen'),
+    launcherType: state.launcher.getIn(['geth', 'type']),
   }),
   (dispatch, ownProps) => ({})
 )(Render);

--- a/src/components/layout/Main/main.js
+++ b/src/components/layout/Main/main.js
@@ -15,7 +15,7 @@ const maxWidth = '1150px';
 const Render = translate('common')(({ t, ...props }) => {
   return (
     <div>
-      {props.screen !== 'welcome' && props.screen !== 'paper-wallet' && <Header maxWidth={ maxWidth }/>}
+      {props.screen !== 'paper-wallet' && <Header maxWidth={ maxWidth }/>}
       <div style={{margin: '20px auto', maxWidth}}>
         <Screen />
       </div>

--- a/src/components/welcome/welcome.js
+++ b/src/components/welcome/welcome.js
@@ -57,7 +57,7 @@ const Render = ({ message, level, ready, needSetup }) => {
   }
 
   return (
-    <Grid id="welcome-screen">
+    <Grid id="welcome-screen" style={{maxWidth: '1150px'}}>
       <Row center="xs" style={logoStyles.row}>
         <Col xs>
           <LogoIcon width="128px" height="128px" />


### PR DESCRIPTION
solution: show header on welcome screen

![image](https://user-images.githubusercontent.com/364566/37271235-393e9fa4-258f-11e8-8c16-e58e55a2ec93.png)

fixes #344 
fixes #380 
fixes #522 
fixes #481 
fixes #521 
fixes #495 
fixes #492 
fixes #446 
fixes #525 


this solves some startup loop problems for people trying to use `epool` and it being down or giving `502`'s. they should be able to switch back to mainnet or gastracker