### PR TITLE
problem: epool is experiencing heavy traffic

### DIFF
--- a/src/components/welcome/NodeTypeChoice/nodeTypeChoice.js
+++ b/src/components/welcome/NodeTypeChoice/nodeTypeChoice.js
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import { Button, Card } from 'emerald-js-ui';
 
 import { useRpc } from '../../../store/launcher/launcherActions';
-import { MainnetEpool, MainnetLocal } from '../../../lib/rpc/gethProviders';
+import { GastrackerMainnet, MainnetLocal } from '../../../lib/rpc/gethProviders';
 import FullNodeLogo from './fullNodeLogo';
 import RemoteNodeLogo from './remoteNodeLogo';
 
@@ -62,7 +62,7 @@ export default connect(
       dispatch(useRpc(MainnetLocal));
     },
     useRemoteNode: () => {
-      dispatch(useRpc(MainnetEpool));
+      dispatch(useRpc(GastrackerMainnet));
     },
   })
 )(NodeTypeChoice);

--- a/src/lib/networks.js
+++ b/src/lib/networks.js
@@ -14,18 +14,6 @@ export const Networks = [
   {
     geth: {
       type: 'remote',
-      url: 'https://mewapi.epool.io',
-    },
-    chain: {
-      id: 61,
-      name: 'mainnet',
-    },
-    title: 'Mainnet (epool.io)',
-    id: 'epool/mainnet',
-  },
-  {
-    geth: {
-      type: 'remote',
       url: 'https://web3.gastracker.io',
     },
     chain: {
@@ -34,6 +22,18 @@ export const Networks = [
     },
     title: 'Mainnet (gastracker.io)',
     id: 'gastracker/mainnet',
+  },
+  {
+    geth: {
+      type: 'remote',
+      url: 'https://mewapi.epool.io',
+    },
+    chain: {
+      id: 61,
+      name: 'mainnet',
+    },
+    title: 'Mainnet (epool.io)',
+    id: 'epool/mainnet',
   },
   {
     geth: {

--- a/src/lib/rpc/gethProviders.js
+++ b/src/lib/rpc/gethProviders.js
@@ -19,3 +19,14 @@ export const MainnetEpool = {
     name: 'mainnet',
   },
 };
+
+export const GastrackerMainnet = {
+  geth: {
+    type: 'remote',
+    url: 'https://web3.gastracker.io',
+  },
+  chain: {
+    id: 61,
+    name: 'mainnet',
+  },
+};


### PR DESCRIPTION
solution: move epool down the network select menu in favor of gastracker.io

![image](https://user-images.githubusercontent.com/364566/37311450-8096a070-2604-11e8-98bf-e86b6f930d1b.png)
