### PR TITLE
problem: syncing takes a long time

### DIFF
--- a/electron/launcher.js
+++ b/electron/launcher.js
@@ -32,7 +32,7 @@ class LocalGeth {
             '--rpc',
             '--rpc-port', this.rpcPort,
             '--rpc-cors-domain', 'http://localhost:8000',
-            '--cache=128',
+            '--cache=1024',
             '--fast', // (auto-disables when at or upon reaching current bc height)
             '--log-dir', logTarget,
           ];


### PR DESCRIPTION
solution: set cache to 1024mb for a performance increase in syncing

fixes #512 

I've tested this, I was able to do a full sync in 3 hours from emerald-wallet as opposed to 1-2days with it set as the default.