### PR TITLE
Add Chainkorea remote node

### DIFF
--- a/src/lib/networks.js
+++ b/src/lib/networks.js
@@ -26,6 +26,18 @@ export const Networks = [
   {
     geth: {
       type: 'remote',
+      url: 'https://node.classicexplorer.org',
+    },
+    chain: {
+      id: 61,
+      name: 'mainnet',
+    },
+    title: 'Mainnet (Chainkorea)',
+    id: 'chainkorea/mainnet',
+  },
+  {
+    geth: {
+      type: 'remote',
       url: 'https://mew.epool.io/',
     },
     chain: {

--- a/src/lib/rpc/gethProviders.js
+++ b/src/lib/rpc/gethProviders.js
@@ -30,3 +30,14 @@ export const GastrackerMainnet = {
     name: 'mainnet',
   },
 };
+
+export const ChainkoreaMainnet = {
+  geth: {
+    type: 'remote',
+    url: 'https://node.classicexplorer.org',
+  },
+  chain: {
+    id: 61,
+    name: 'mainnet',
+  },
+};


### PR DESCRIPTION
Node used and maintained by Chainkorea (https://github.com/chainkorea)

+ HTTPS & Load Balancing through AWS (https://github.com/chainkorea/docker-etc-lb)
+ Blockchain up to date.
+ Response time ~150-350ms
+ KR servers
+ Live stats page on https://classicstats.net
+ Already used by ClassicEtherWallet