### PR TITLE
Problem: method not exist error on morden when switching networks

### DIFF
--- a/src/store/network/networkActions.js
+++ b/src/store/network/networkActions.js
@@ -46,6 +46,8 @@ export function loadAddressTransactions(...props) {
       return api.geth.ext.getTransactions(result).then((txes) => {
         return Promise.all(txes.map((tx) => dispatch(history.actions.trackTx(tx.result))));
       });
+    }).catch((e) => {
+      log.error(e);
     });
   };
 }


### PR DESCRIPTION
Solution: suppress error and use the redux logger to log it

fixes #653 
fixes #654 
